### PR TITLE
Fixes #1 by handling null data in response

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.internal.impldep.org.joda.time.Instant
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val kotlinVersion = "1.3.21"
-val versionNo = "1.0.0"
+val versionNo = "1.0.1"
 
 project.group = "com.github.excitement-engineer"
 project.version = versionNo

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     testImplementation("io.ktor:ktor-server-jetty:1.1.3")
     testImplementation("com.graphql-java:graphql-java-tools:3.2.0")
     testImplementation("junit:junit:4.11")
+    testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.9.1")
+
 }
 
 tasks {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+bintrayUser=PLACEHOLDER_USER
+bintrayApiKey=PLACEHOLDER_API_KEY

--- a/src/main/kotlin/klient/graphql/internal/parsers/utilities.kt
+++ b/src/main/kotlin/klient/graphql/internal/parsers/utilities.kt
@@ -47,10 +47,11 @@ internal fun <T>JsonNode.parse(responseClass: Class<T>): T {
     return response
 }
 
-internal fun ObjectNode.safeGet(name: String): JsonNode? {
-    return if (has(name)) {
-        get(name)
+internal fun ObjectNode.safeGet(name: String): JsonNode? =
+    if (this.has(name)) {
+        val got = this.get(name)
+        if (got.isNull) null else got
     } else {
         null
     }
-}
+

--- a/src/test/kotlin/klient/graphql/ClientTest.kt
+++ b/src/test/kotlin/klient/graphql/ClientTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.assertNull
 
 class ClientTest {
 
@@ -334,4 +335,18 @@ class ClientTest {
         )
     }
 
+    @Test
+    fun `real errors`() {
+        val clientWrong = GraphQLClient(
+                endpoint = "http://localhost:$serverPort/realerror"
+        )
+
+        val x = clientWrong.performRequest<Response>(
+                GraphQLRequest( query = "badquery { oops }" )
+        )
+
+        assertTrue(x.hasErrors)
+        assertNull(x.data)
+        assertTrue(x.errors.size > 0)
+    }
 }

--- a/src/test/kotlin/klient/graphql/ClientTest.kt
+++ b/src/test/kotlin/klient/graphql/ClientTest.kt
@@ -338,15 +338,15 @@ class ClientTest {
     @Test
     fun `real errors`() {
         val clientWrong = GraphQLClient(
-                endpoint = "http://localhost:$serverPort/realerror"
+                endpoint = "http://localhost:$serverPort/error-no-data"
         )
 
-        val x = clientWrong.performRequest<Response>(
-                GraphQLRequest( query = "badquery { oops }" )
+        val response = clientWrong.performRequest<Response>(
+                GraphQLRequest( query = "query" )
         )
 
-        assertTrue(x.hasErrors)
-        assertNull(x.data)
-        assertTrue(x.errors.size > 0)
+        assertTrue(response.hasErrors)
+        assertNull(response.data)
+        assertTrue(response.errors.isNotEmpty())
     }
 }

--- a/src/test/kotlin/klient/graphql/helpers/server.kt
+++ b/src/test/kotlin/klient/graphql/helpers/server.kt
@@ -41,7 +41,17 @@ val server: ApplicationEngine = embeddedServer(Jetty, serverPort) {
             post {
                 call.respond(HttpStatusCode.InternalServerError, "Something went wrong")
             }
+        }
 
+        route("realerror") {
+            post {
+                call.respond(HttpStatusCode.OK, """
+                       {"errors":[{"message":"Invalid Syntax : offending token 'badquery' at line 1 column 1","sourcePreview":"badquery { oops }\n","offendingToken":"badquery","locations":[{"line":1,"column":1,"sourceName":null}],"errorType":"InvalidSyntax","path":null,"extensions":null}],
+                       "data":null,
+                       "extensions":null,
+                       "dataPresent":false}
+                """)
+            }
         }
     }
 }

--- a/src/test/kotlin/klient/graphql/helpers/server.kt
+++ b/src/test/kotlin/klient/graphql/helpers/server.kt
@@ -43,13 +43,19 @@ val server: ApplicationEngine = embeddedServer(Jetty, serverPort) {
             }
         }
 
-        route("realerror") {
+        route("error-no-data") {
             post {
                 call.respond(HttpStatusCode.OK, """
-                       {"errors":[{"message":"Invalid Syntax : offending token 'badquery' at line 1 column 1","sourcePreview":"badquery { oops }\n","offendingToken":"badquery","locations":[{"line":1,"column":1,"sourceName":null}],"errorType":"InvalidSyntax","path":null,"extensions":null}],
-                       "data":null,
-                       "extensions":null,
-                       "dataPresent":false}
+                       {
+                           "errors":[
+                              {
+                                 "message":"Invalid Syntax"
+                              }
+                           ],
+                           "data":null,
+                           "extensions":null,
+                           "dataPresent":false
+                        }
                 """)
             }
         }

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appenders>
+        <console name="stdout" target="SYSTEM_OUT">
+            <patternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5level - %m%n" />
+        </console>
+    </appenders>
+
+    <loggers>
+        <root level="off">
+            <appender-ref ref="stdout" level="all"/>
+        </root>
+    </loggers>
+</configuration>


### PR DESCRIPTION
Fixes #1 

For graphql errors, some servers like Apollo will return null `data`,  true `hasErrors`, and populated `errors` array.  The code wasn't handling this case and would throw a stack from assertIsObject() trying to deserialize null JSON data.