### PR TITLE
New client api performGenericRequest allows for custom graphql errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,39 @@ val response = client.performRequest<Response>(
     )
 
 ```
+
+
+### Using Generic Error
+The `performGenericRequest` method allows developers to handle error responses from GraphQL servers that add additional information which does not exist in the GraphQL Specification.
+```kt
+data class CustomGraphQLError (
+        val message: String,
+        val locations: List<Location> = emptyList(),
+        val path: List<String> = emptyList(),
+        val extensions: Map<String, Any> = emptyMap(),
+        val test: String,
+        val customMessage: String
+)
+
+data class Response(
+    val person: Person
+)
+
+val client = GraphQLClient("http://example.com/graphql")
+
+val query = """ {
+                   person {
+                        name
+                        age
+                        school {
+                           name
+                           address
+                        }
+                   }
+
+               } """.trimIndent()
+
+val response = genericClient.performGenericRequest<Response, CustomGraphQLError>( GraphQLRequest(query = query))
+
+
+```

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ val query = """ {
 
                } """.trimIndent()
 
-val response = genericClient.performGenericRequest<Response, CustomGraphQLError>( GraphQLRequest(query = query))
+val response = client.performGenericRequest<Response, CustomGraphQLError>( GraphQLRequest(query = query))
 
 
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.internal.impldep.org.joda.time.Instant
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val kotlinVersion = "1.3.21"
-val versionNo = "1.1"
+val versionNo = "1.1.0"
 
 project.group = "com.github.excitement-engineer"
 project.version = versionNo

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.internal.impldep.org.joda.time.Instant
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val kotlinVersion = "1.3.21"
-val versionNo = "1.0.1"
+val versionNo = "1.1"
 
 project.group = "com.github.excitement-engineer"
 project.version = versionNo

--- a/src/main/kotlin/klient/graphql/GenericGraphQLResponse.kt
+++ b/src/main/kotlin/klient/graphql/GenericGraphQLResponse.kt
@@ -1,0 +1,9 @@
+package klient.graphql
+
+data class GenericGraphQLResponse<Data, Error> (
+    val data: Data? = null,
+    val errors: List<Error> = emptyList()
+) {
+    val hasErrors = errors.isNotEmpty()
+
+}

--- a/src/main/kotlin/klient/graphql/GraphQLClient.kt
+++ b/src/main/kotlin/klient/graphql/GraphQLClient.kt
@@ -1,6 +1,7 @@
 package klient.graphql
 
 import klient.graphql.internal.http.performHttpRequest
+import klient.graphql.internal.parsers.parseGenericResponse
 import klient.graphql.internal.parsers.parseResponse
 import klient.graphql.internal.serializers.serialize
 
@@ -19,6 +20,19 @@ data class GraphQLClient(
         )
 
         return parseResponse(httpResponse)
+    }
+
+    inline fun <reified Data, reified Error> performGenericRequest(request: GraphQLRequest): GenericGraphQLResponse<Data, Error> {
+
+        val requestBody = request.serialize()
+
+        val httpResponse = performHttpRequest(
+                url = endpoint,
+                headers = headers,
+                requestBody = requestBody
+        )
+
+        return parseGenericResponse(httpResponse)
     }
 }
 

--- a/src/main/kotlin/klient/graphql/internal/parsers/graphQLError.kt
+++ b/src/main/kotlin/klient/graphql/internal/parsers/graphQLError.kt
@@ -11,6 +11,11 @@ internal fun ArrayNode.parseErrors(): List<GraphQLError> = map { errorObject ->
         .parseError()
 }
 
+internal fun <T>ArrayNode.parseGenericErrors(errorClass: Class<T>): List<T> = map { errorObject ->
+    errorObject
+            .assertIsObject()
+            .parse(errorClass)
+}
 
 private fun ObjectNode.parseError(): GraphQLError {
 

--- a/src/main/kotlin/klient/graphql/internal/parsers/graphQLResponse.kt
+++ b/src/main/kotlin/klient/graphql/internal/parsers/graphQLResponse.kt
@@ -1,5 +1,6 @@
 package klient.graphql.internal.parsers
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import klient.graphql.GenericGraphQLResponse
 import klient.graphql.internal.http.HTTPResponse
 import klient.graphql.internal.http.assertIsValid
@@ -13,18 +14,11 @@ internal inline fun <reified Data> parseResponse(httpResponse: HTTPResponse) =
 internal inline fun <reified Data, reified Error> parseGenericResponse(httpResponse: HTTPResponse) =
         parseGenericResponse(httpResponse, Data::class.java, Error::class.java)
 
-//GenericGraphQLResponse<Data, Error>
 
 @PublishedApi
 internal fun <Data> parseResponse(httpResponse: HTTPResponse, responseClass: Class<Data>): GraphQLResponse<Data> {
 
-    val validResponse = httpResponse.assertIsValid()
-
-    val (response) = validResponse
-
-    val jsonResponse = response
-        .toJson()
-        .assertIsObject()
+    val jsonResponse = parseJsonResponse(httpResponse)
 
     val data = jsonResponse
         .safeGet("data")
@@ -45,13 +39,7 @@ internal fun <Data> parseResponse(httpResponse: HTTPResponse, responseClass: Cla
 @PublishedApi
 internal fun <Data, Error> parseGenericResponse(httpResponse: HTTPResponse, responseClass: Class<Data>, errorClass: Class<Error>): GenericGraphQLResponse<Data, Error> {
 
-    val validResponse = httpResponse.assertIsValid()
-
-    val (response) = validResponse
-
-    val jsonResponse = response
-            .toJson()
-            .assertIsObject()
+    val jsonResponse = parseJsonResponse(httpResponse)
 
     val data = jsonResponse
             .safeGet("data")
@@ -67,4 +55,15 @@ internal fun <Data, Error> parseGenericResponse(httpResponse: HTTPResponse, resp
             data = data,
             errors = errors ?: emptyList()
     )
+}
+
+private fun parseJsonResponse(httpResponse: HTTPResponse): ObjectNode {
+    val validResponse = httpResponse.assertIsValid()
+
+    val (response) = validResponse
+
+    val jsonResponse = response
+            .toJson()
+            .assertIsObject()
+    return jsonResponse
 }

--- a/src/main/kotlin/klient/graphql/internal/parsers/graphQLResponse.kt
+++ b/src/main/kotlin/klient/graphql/internal/parsers/graphQLResponse.kt
@@ -1,5 +1,6 @@
 package klient.graphql.internal.parsers
 
+import klient.graphql.GenericGraphQLResponse
 import klient.graphql.internal.http.HTTPResponse
 import klient.graphql.internal.http.assertIsValid
 import klient.graphql.GraphQLResponse
@@ -7,6 +8,12 @@ import klient.graphql.GraphQLResponse
 @PublishedApi
 internal inline fun <reified Data> parseResponse(httpResponse: HTTPResponse) =
     parseResponse(httpResponse, Data::class.java)
+
+@PublishedApi
+internal inline fun <reified Data, reified Error> parseGenericResponse(httpResponse: HTTPResponse) =
+        parseGenericResponse(httpResponse, Data::class.java, Error::class.java)
+
+//GenericGraphQLResponse<Data, Error>
 
 @PublishedApi
 internal fun <Data> parseResponse(httpResponse: HTTPResponse, responseClass: Class<Data>): GraphQLResponse<Data> {
@@ -32,5 +39,32 @@ internal fun <Data> parseResponse(httpResponse: HTTPResponse, responseClass: Cla
     return GraphQLResponse(
         data = data,
         errors = errors ?: emptyList()
+    )
+}
+
+@PublishedApi
+internal fun <Data, Error> parseGenericResponse(httpResponse: HTTPResponse, responseClass: Class<Data>, errorClass: Class<Error>): GenericGraphQLResponse<Data, Error> {
+
+    val validResponse = httpResponse.assertIsValid()
+
+    val (response) = validResponse
+
+    val jsonResponse = response
+            .toJson()
+            .assertIsObject()
+
+    val data = jsonResponse
+            .safeGet("data")
+            ?.assertIsObject()
+            ?.parse(responseClass)
+
+    val errors = jsonResponse
+            .safeGet("errors")
+            ?.assertIsList()
+            ?.parseGenericErrors(errorClass)
+
+    return GenericGraphQLResponse(
+            data = data,
+            errors = errors ?: emptyList()
     )
 }

--- a/src/test/kotlin/klient/graphql/helpers/models.kt
+++ b/src/test/kotlin/klient/graphql/helpers/models.kt
@@ -1,5 +1,7 @@
 package klient.graphql.helpers
 
+import klient.graphql.Location
+
 data class Person(
     val name: String,
     val age: Int,
@@ -30,5 +32,14 @@ data class AuthenticatedResponse(
 data class PersonWithoutSchool(
     val name: String,
     val age: Int
+)
+
+data class CustomGraphQLError (
+        val message: String,
+        val locations: List<Location> = emptyList(),
+        val path: List<String> = emptyList(),
+        val extensions: Map<String, Any> = emptyMap(),
+        val test: String,
+        val customMessage: String
 )
 

--- a/src/test/kotlin/klient/graphql/helpers/server.kt
+++ b/src/test/kotlin/klient/graphql/helpers/server.kt
@@ -37,6 +37,27 @@ val server: ApplicationEngine = embeddedServer(Jetty, serverPort) {
             }
         }
 
+        graphQL("/graphql-generic", schema) {
+            config {
+                context = Context(
+                        accessToken = call.request.header("Authorization")
+                )
+
+                formatError = {
+
+                    val error = toSpecification()
+
+                    error["extensions"] = mapOf(
+                            "reason" to "unknown"
+                    )
+                    error["customMessage"] = "customMessage"
+                    error["test"] = "test"
+
+                    error
+                }
+            }
+        }
+
         route("error") {
             post {
                 call.respond(HttpStatusCode.InternalServerError, "Something went wrong")


### PR DESCRIPTION
The GraphQL specification has gone through changes with regards to the error specification seen [here](https://spec.graphql.org/June2018/#sec-Errors). The specification refers to preferred and non preferred ways of representing errors. In the most recent specification update from 2018, extensions are used to hold extra information that organizations may need to make their error handling more robust.  Many organizations have used GraphQL prior to the addition of extensions in 2018 and therefore have created custom Error objects for their GraphQL schema implementations. To make this graphql client more robust and gain the ability to handle GraphQL errors that don't follow the current specification I thought I would add a `performGenericRequest` that can handle custom error objects. Please review and share your thoughts.